### PR TITLE
Just extending the idea in bmc/grizzled-slf4j@19989dc 

### DIFF
--- a/src/main/scala/grizzled/slf4j/slf4j.scala
+++ b/src/main/scala/grizzled/slf4j/slf4j.scala
@@ -45,7 +45,7 @@ import org.slf4j.{Logger => SLF4JLogger}
 /**
  * Scala front-end to a SLF4J logger.
  */
-class Logger(val logger: SLF4JLogger)
+final class Logger(val logger: SLF4JLogger)
 {
     /**
      * Get the name associated with this logger.
@@ -207,7 +207,7 @@ trait Logging
     /**
      * Determine whether trace logging is enabled.
      */
-    protected def isTraceEnabled = logger.isTraceEnabled
+    @inline protected final def isTraceEnabled = logger.isTraceEnabled
 
     /**
      * Issue a trace logging message.
@@ -215,7 +215,7 @@ trait Logging
      * @param msg  the message object. `toString()` is called to convert it
      *             to a loggable string.
      */
-    protected def trace(msg: => AnyRef): Unit = logger.trace(msg)
+    @inline protected final def trace(msg: => AnyRef): Unit = logger.trace(msg)
 
     /**
      * Issue a trace logging message, with an exception.
@@ -224,13 +224,13 @@ trait Logging
      *             to a loggable string.
      * @param t    the exception to include with the logged message.
      */
-    protected def trace(msg: => AnyRef, t: => Throwable): Unit =
+    @inline protected final def trace(msg: => AnyRef, t: => Throwable): Unit =
         logger.trace(msg, t)
 
     /**
      * Determine whether debug logging is enabled.
      */
-    protected def isDebugEnabled = logger.isDebugEnabled
+    @inline protected final def isDebugEnabled = logger.isDebugEnabled
 
     /**
      * Issue a debug logging message.
@@ -238,7 +238,7 @@ trait Logging
      * @param msg  the message object. `toString()` is called to convert it
      *             to a loggable string.
      */
-    protected def debug(msg: => AnyRef): Unit = logger.debug(msg)
+    @inline protected final def debug(msg: => AnyRef): Unit = logger.debug(msg)
 
     /**
      * Issue a debug logging message, with an exception.
@@ -247,13 +247,13 @@ trait Logging
      *             to a loggable string.
      * @param t    the exception to include with the logged message.
      */
-    protected def debug(msg: => AnyRef, t: => Throwable): Unit =
+    @inline protected final def debug(msg: => AnyRef, t: => Throwable): Unit =
         logger.debug(msg, t)
 
     /**
      * Determine whether trace logging is enabled.
      */
-    protected def isErrorEnabled = logger.isErrorEnabled
+    @inline protected final def isErrorEnabled = logger.isErrorEnabled
 
     /**
      * Issue a trace logging message.
@@ -261,7 +261,7 @@ trait Logging
      * @param msg  the message object. `toString()` is called to convert it
      *             to a loggable string.
      */
-    protected def error(msg: => AnyRef): Unit = logger.error(msg)
+    @inline protected final def error(msg: => AnyRef): Unit = logger.error(msg)
 
     /**
      * Issue a trace logging message, with an exception.
@@ -270,13 +270,13 @@ trait Logging
      *             to a loggable string.
      * @param t    the exception to include with the logged message.
      */
-    protected def error(msg: => AnyRef, t: => Throwable): Unit =
+    @inline protected final def error(msg: => AnyRef, t: => Throwable): Unit =
         logger.error(msg, t)
 
     /**
      * Determine whether trace logging is enabled.
      */
-    protected def isInfoEnabled = logger.isInfoEnabled
+    @inline protected final def isInfoEnabled = logger.isInfoEnabled
 
     /**
      * Issue a trace logging message.
@@ -284,7 +284,7 @@ trait Logging
      * @param msg  the message object. `toString()` is called to convert it
      *             to a loggable string.
      */
-    protected def info(msg: => AnyRef): Unit = logger.info(msg)
+    @inline protected final def info(msg: => AnyRef): Unit = logger.info(msg)
 
     /**
      * Issue a trace logging message, with an exception.
@@ -293,13 +293,13 @@ trait Logging
      *             to a loggable string.
      * @param t    the exception to include with the logged message.
      */
-    protected def info(msg: => AnyRef, t: => Throwable): Unit =
+    @inline protected final def info(msg: => AnyRef, t: => Throwable): Unit =
         logger.info(msg, t)
 
     /**
      * Determine whether trace logging is enabled.
      */
-    protected def isWarnEnabled = logger.isWarnEnabled
+    @inline protected final def isWarnEnabled = logger.isWarnEnabled
 
     /**
      * Issue a trace logging message.
@@ -307,7 +307,7 @@ trait Logging
      * @param msg  the message object. `toString()` is called to convert it
      *             to a loggable string.
      */
-    protected def warn(msg: => AnyRef): Unit = logger.warn(msg)
+    @inline protected final def warn(msg: => AnyRef): Unit = logger.warn(msg)
 
     /**
      * Issue a trace logging message, with an exception.
@@ -316,7 +316,7 @@ trait Logging
      *             to a loggable string.
      * @param t    the exception to include with the logged message.
      */
-    protected def warn(msg: => AnyRef, t: => Throwable): Unit =
+    @inline protected final def warn(msg: => AnyRef, t: => Throwable): Unit =
         logger.warn(msg, t)
 }
 


### PR DESCRIPTION
Make the `Logger` class itself final (unless you can think of a good reason to extend it?) and all methods in `Logging` trait which aren't useful to override.
