### PR TITLE
Allow any type to be logged, plus nulls

### DIFF
--- a/src/main/scala/grizzled/slf4j/slf4j.scala
+++ b/src/main/scala/grizzled/slf4j/slf4j.scala
@@ -155,6 +155,13 @@ class Logger(val logger: SLF4JLogger) {
   @inline final def warn(msg: => Any, t: => Throwable): Unit =
     if (isWarnEnabled) logger.warn(msg, t)
 
+  /** Converts any type to a String. In case the object is null, a null 
+    * String is returned. Otherwise the method `toString()` is called.
+    *
+    * @param msg  the message object to be converted to String
+    *
+    * @return the String representation of the message.
+    */
   private implicit def _any2String(msg: Any): String =
     msg match {
       case null => "null"


### PR DESCRIPTION
Hello there,

I've been using the lib nowadays in a webapp and there were two things I was missing. Please let me know if you agree with them:

First off all, is that sometimes I needed to log numbers (Int, Double, etc). For that, I had to call toString to pass the argument to the logging methods. I thought it would be nice to have the framework to do it for you.

Second, it would throw a NPE with nulls :( I was logging some string that just came out of other framework and saw that happening. I really didn't liked to see my app crash because of the logging framework :P

I changed the signature of all the logging methods, and added this method here to convert the messages to strings:
  private implicit def _any2String(msg: Any): String =
    msg match {
      case null => "null"
      case _    => msg.toString
    }

As you can see, nulls will be converted to a "null" string :D
