### PR TITLE
allow Logging Serializable classes to be deserialized

### DIFF
--- a/src/main/scala/grizzled/slf4j/slf4j.scala
+++ b/src/main/scala/grizzled/slf4j/slf4j.scala
@@ -178,7 +178,7 @@ class Logger(val logger: SLF4JLogger) {
   */
 trait Logging {
   // The logger. Instantiated the first time it's used.
-  private lazy val _logger = Logger(getClass)
+  @transient private lazy val _logger = Logger(getClass)
 
   /** Get the `Logger` for the class that mixes this trait in. The `Logger`
     * is created the first time this method is call. The other methods (e.g.,


### PR DESCRIPTION
Found this library today, love it, moved tons of files over to it (from log4j) already.

The one issue I've found is that marking a Serializable class as Logging makes it unserializable - or un-deserializable, rather.

It seems that just marking the logger field as transient allows the class to be deserialized properly, and of course the field is recreated on the deserialized object.
