### PR TITLE
grizzled-slf4j - Mark logger val as transient

### DIFF
--- a/src/main/scala/grizzled/slf4j/slf4j.scala
+++ b/src/main/scala/grizzled/slf4j/slf4j.scala
@@ -231,7 +231,7 @@ class Logger(val logger: SLF4JLogger) {
   */
 trait Logging {
   // The logger. Instantiated the first time it's used.
-  private lazy val _logger = Logger(getClass)
+  @transient private lazy val _logger = Logger(getClass)
 
   /** Get the `Logger` for the class that mixes this trait in. The `Logger`
     * is created the first time this method is call. The other methods (e.g.,


### PR DESCRIPTION
Problem

When the Logging trait is mixed into a Serializable class,
that class is unable to be properly serialized as the `_logger`
reference prevents serialization.

Solution

Mark the `_logger` reference in the Logging trait as
`@transient` allowing for Serializable classes that mix in
the trait to be correctly serialized.

Result

Serializable classes which mix in the Logging trait
can be serialized.

Notes

This patch is my original work and I agree to license it to the Grizzled SLF4J project under a [BSD License](http://software.clapper.org/grizzled-slf4j/license.html).

***
Notes:

I am unable to run the testproject -- please let me know if you think this change necessitates a test case as I have one I can add but will need a bit of guidance as the best way to add and run it given the project's setup.

Thanks.
***