### PR TITLE
Make _logger in Logging trait @transient.

### DIFF
--- a/src/main/scala/grizzled/slf4j/slf4j.scala
+++ b/src/main/scala/grizzled/slf4j/slf4j.scala
@@ -231,7 +231,7 @@ class Logger(val logger: SLF4JLogger) {
   */
 trait Logging {
   // The logger. Instantiated the first time it's used.
-  private lazy val _logger = Logger(getClass)
+  @transient private lazy val _logger = Logger(getClass)
 
   /** Get the `Logger` for the class that mixes this trait in. The `Logger`
     * is created the first time this method is call. The other methods (e.g.,


### PR DESCRIPTION
We've had NPE issues in Spark when using a similar logging trait similar to the one in `grizzled-slf4j`.  To fix, we made the logger transient.  This is similar to what the spark [`org.apache.spark.internal.Logging`](https://github.com/apache/spark/blob/0733a54a4517b82291efed9ac7f7407d9044593c/core/src/main/scala/org/apache/spark/internal/Logging.scala#L35) trait does too.